### PR TITLE
Allow passing data to transmogrify

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ npm install json-transmogrify --save
 ```js
 var transmogrify = require('json-transmogrify');
 
-var source = './file.json'; // or URL to file
+var source = './file.json'; // may be a file path, an URL or a javascript object
 
 var options = {
   // root node of target xml

--- a/lib/transmogrify.js
+++ b/lib/transmogrify.js
@@ -25,15 +25,19 @@ module.exports = function (url, options, cb) {
     var deferred = q.defer();
 
     // transmogrify all the things
-    if (url.substr(0, 4) != 'http') {
-      // assume its a file if it starts with http
+    if (typeof url == 'string' && url.substr(0, 4) == 'http') {
+      // assume its an URL if it starts with http
+      request({url: url, json: true}, function(err, data) {
+        deferred.resolve(transmogrifyCallback(err, rootNode, data.body, template, postRequest, postTransform));
+      });
+    } else if (typeof url == 'string') {
+      // assume its a file if its a string that didn't start with http
       fs.readFile(url, function(err, data) {
         deferred.resolve(transmogrifyCallback(err, rootNode, JSON.parse(data), template, postRequest, postTransform));
       });
     } else {
-      request({url: url, json: true}, function(err, data) {
-        deferred.resolve(transmogrifyCallback(err, rootNode, data.body, template, postRequest, postTransform));
-      });
+      // assume data was passed in
+      deferred.resolve(transmogrifyCallback(null, rootNode, url, template, postRequest, postTransform));
     }
     return deferred.promise;
 };

--- a/spec/test.js
+++ b/spec/test.js
@@ -50,4 +50,11 @@ describe('transmogrify lib', function() {
     });
   });
 
+  it('allows passing data as an object and converts it', function(done) {
+    sut({}).then(function(result) {
+      expect(result).toEqual(fs.readFileSync('./spec/fixtures/empty.xml') + '');
+      done();
+    });
+  });
+
 });


### PR DESCRIPTION
Instead of only allowing URLs and file paths as an argument to transmogrify this also allows passing raw data as a javascript object.

The use case for this is being able to have transmogrify run multiple times based on only one given resource. Using this I can fetch whatever is needed, split it into parts and call transmogrify on those parts individually.
